### PR TITLE
Removido a necessidade de existir a propriedade Attributes em um Objeto

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -29,7 +29,7 @@ function parseJsonApiSimpleResourceData (data, included, useCache, options) {
     return included.cached[data.type][data.id]
   }
 
-  let attributes = data.attributes
+  let attributes = data.attributes || {}
 
   if (options.changeCase) {
     attributes = changeCase(attributes, options.changeCase)

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -54,4 +54,42 @@ describe('deserialize', () => {
       }
     ])
   })
+
+  it('Deserialize data without attributes', () => {
+    const serialized = {
+      data: [
+        {
+          type: 'users',
+          id: 1,
+          relationships: {
+            address: {
+              data: {
+                type: 'addr',
+                id: 1
+              }
+            }
+          }
+        }
+      ],
+      included: [
+        {
+          type: 'addr',
+          id: 1,
+          attributes: {
+            street: 'Street 1'
+          }
+        }
+      ]
+    }
+
+    expect(deserialize(serialized)).toEqual([
+      {
+        id: 1,
+        address: {
+          id: 1,
+          street: 'Street 1'
+        }
+      }
+    ])
+  })
 });


### PR DESCRIPTION
## Descrição:
-  Segundo a [documentação](https://jsonapi.org/format/#document-top-level) do JsonAPI  a propriedade `attributes` não deve ser obrigatória. 

## O que foi feito no PR?
-  Removido necessidade da prop `attributes`.
- Feito teste para garantir a "deserialização" de um objeto sem a prop `attributes`.

@andersondanilo 