### PR TITLE
Add deep option to changeCase

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -32,7 +32,7 @@ function parseJsonApiSimpleResourceData (data, included, useCache, options) {
   let attributes = data.attributes || {}
 
   if (options.changeCase) {
-    attributes = changeCase(attributes, options.changeCase)
+    attributes = changeCase(attributes, options.changeCase, options.deep)
   }
 
   const resource = attributes

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -82,7 +82,7 @@ function serializeEntity (entity, transformer: Transformer, options: Options, in
   }
 
   if (options.changeCase) {
-    attributes = changeCase(attributes, options.changeCase)
+    attributes = changeCase(attributes, options.changeCase, options.deep)
   }
 
   const data = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { camelCase, snakeCase, paramCase } from 'change-case'
 
-export function changeCase (attributes, caseType) {
+export function changeCase (attributes, caseType, deep = false) {
   const caseTypes = {
     camelCase,
     snakeCase,
@@ -17,7 +17,14 @@ export function changeCase (attributes, caseType) {
   const newAttributes = {}
 
   for (const key of Object.keys(attributes)) {
-    newAttributes[caseFn(key)] = attributes[key]
+    if (
+      deep &&
+      Object.prototype.toString.call(attributes[key]) === '[object Object]'
+    ) {
+      newAttributes[caseFn(key)] = changeCase(attributes[key], caseType, deep)
+    } else {
+      newAttributes[caseFn(key)] = attributes[key]
+    }
   }
 
   return newAttributes

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -9,7 +9,12 @@ describe('deserialize', () => {
           id: 1,
           attributes: {
             'first-name': 'Joe',
-            'last-name': 'Doe'
+            'last-name': 'Doe',
+            'birthday': {
+              'day-of-birth': 1,
+              'month-of-birth': 1,
+              'year-of-birth': 1970
+            }
           },
           relationships: {
             address: {
@@ -38,11 +43,16 @@ describe('deserialize', () => {
       ]
     }
 
-    expect(deserialize(serialized, { changeCase: 'camelCase' })).toEqual([
+    expect(deserialize(serialized, { changeCase: 'camelCase', deep: true })).toEqual([
       {
         id: 1,
         firstName: 'Joe',
         lastName: 'Doe',
+        birthday: {
+          dayOfBirth: 1,
+          monthOfBirth: 1,
+          yearOfBirth: 1970
+        },
         address: {
           id: 1,
           street: 'Street 1'


### PR DESCRIPTION
## Motivation:

The JSON API specs says that the `Complex data structures involving JSON objects and arrays are allowed as attribute values.`. In order to support that, we need to have the ability to support deep case changing.
https://jsonapi.org/format/#document-resource-object-attributes

## Changes:

Add the `deep` option.
This option defaults to `false`.
When set to `true`, a deep case changing is applied to the complex attributes.
An example is added to the test: [tests/deserialize.spec.ts](https://github.com/andersondanilo/jsonapi-fractal/blob/d74ce296c6dec7a3ab07b8b9e768d8041a1988ed/tests/deserialize.spec.ts)