### PR TITLE
fix: issues with includes cause by ids based on slugs like "reverse"

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -152,7 +152,7 @@ function serializeRelation<TEntity = unknown, TExtraOptions = unknown>(
       includedByType[transformer.type] = {}
     }
 
-    if (!(id in includedByType[transformer.type])) {
+    if (!Object.prototype.hasOwnProperty.call(includedByType[transformer.type], id)) {
       includedByType[transformer.type][id] = serializeEntity(
         entity,
         transformer,


### PR DESCRIPTION
If the id of the related resource is a valid method/property of the object like "reverse" it will skip the includes during the serialization.

expected result:
```json
{
  "data": {
    "id": "main-resource",
    "type": "x",
    "attributes": {
      "name": "Main resource",
      "slug": "main-resource",
      "status": "Live"
    },
    "relationships": {
      "templates": {
        "data": [
          {
            "type": "y",
            "id": "reverse"
          }
        ]
      }
    }
  },
  "included": [
    {
      "id": "reverse",
      "type": "y",
      "attributes": {
        "name": "Reverse",
        "slug": "reverse",
        "status": "Live"
      }
    }
  ]
}
```

current result:
```json
{
  "data": {
    "id": "main-resource",
    "type": "x",
    "attributes": {
      "name": "Main resource",
      "slug": "main-resource",
      "status": "Live"
    },
    "relationships": {
      "templates": {
        "data": [
          {
            "type": "y",
            "id": "reverse"
          }
        ]
      }
    }
  }
}
```

changing the way that the id is validated solves this issue