### PR TITLE
feat: custom relationship types

### DIFF
--- a/src/default-transformer.ts
+++ b/src/default-transformer.ts
@@ -5,14 +5,19 @@ import { createRecordFromKeys } from './utils'
 export class DefaultTransformer<TEntity = unknown, TExtraOptions = void> extends Transformer<TEntity, TExtraOptions> {
   public readonly relationships: Record<string, RelationshipTransformerInfoFunction<TEntity, TExtraOptions>>
 
-  constructor(public type: string, relationshipNames: string[] = []) {
+  constructor(public type: string, relationships: string[] | Record<string, string> = []) {
     super()
+
+    const relationshipNames = Array.isArray(relationships) ? relationships : Object.keys(relationships)
 
     this.relationships = createRecordFromKeys(relationshipNames, (relationName: string) => {
       return (entity: TEntity): RelationshipTransformerInfo<TExtraOptions> => {
         return {
           input: entity[relationName as never] as unknown,
-          transformer: new DefaultTransformer<unknown, TExtraOptions>(relationName, []),
+          transformer: new DefaultTransformer<unknown, TExtraOptions>(
+            Array.isArray(relationships) ? relationName : relationships[relationName],
+            [],
+          ),
           included: false,
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,4 +60,6 @@ export type Options<TExtraOptions = void> = {
   extra?: TExtraOptions
 }
 
-export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & { relationships?: string[] }
+export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
+  relationships?: string[] | Record<string, string>
+}

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -109,4 +109,32 @@ describe('serialize', () => {
       },
     })
   })
+
+  it('should set relationship types appropriately', () => {
+    const serialized = serialize(validEntity, 'users', {
+      relationships: { address: 'locations' },
+    })
+
+    expect(serialized).toStrictEqual({
+      data: {
+        type: 'users',
+        attributes: {
+          firstName: 'Joe',
+          lastName: 'Doe',
+          images: [
+            { id: 'image-1', name: 'myimage1', width: 100 },
+            { id: 'image-2', name: 'myimage2', width: 100 },
+          ],
+        },
+        relationships: {
+          address: {
+            data: {
+              type: 'locations',
+              id: 'address-1',
+            },
+          },
+        },
+      },
+    })
+  })
 })


### PR DESCRIPTION
When serializing data with relationships, the relationship type is currently set to whatever the key on the data object is. This isn't always desired. We could have two relationship properties that are of the same type, but they cannot share a key in typescript.

Change the serialize relationships property to accept a string array of property names _or_ a mapping from property name to the related resource's type.