### PR TITLE
fix: changeCase for relation names

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -1,5 +1,5 @@
 import { AttributesObject, DocumentObject, ExistingResourceObject, Options, ResourceObject } from './types'
-import { changeCase } from './utils'
+import { caseTypes, changeCase } from './utils'
 
 type IncludedCache = Record<string, Record<string, unknown>>
 
@@ -70,8 +70,13 @@ function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
         continue
       }
 
+      let casedRelationName = relationName
+      if (options.changeCase) {
+        casedRelationName = caseTypes[options.changeCase](relationName)
+      }
+
       if (Array.isArray(relationReference.data)) {
-        resource[relationName] = relationReference.data.map((relationData) => {
+        resource[casedRelationName] = relationReference.data.map((relationData) => {
           return findJsonApiIncluded(included, includedCache, relationData.type, relationData.id, options)
         })
       } else if (relationReference && relationReference.data) {
@@ -87,7 +92,7 @@ function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
           relationResource.links = relationReference.links
         }
 
-        resource[relationName] = relationResource
+        resource[casedRelationName] = relationResource
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,11 @@ import { camelCase, snakeCase, paramCase } from 'change-case'
 import { AttributesObject, CaseType, JsonObject } from './types'
 
 type CaseFunction = (input: string) => string
+export const caseTypes: Record<CaseType, CaseFunction> = {
+  [CaseType.camelCase]: camelCase,
+  [CaseType.snakeCase]: snakeCase,
+  [CaseType.kebabCase]: paramCase,
+}
 
 /**
  * Used to change the case (e.g. captalization) of the keys of a object
@@ -11,12 +16,6 @@ type CaseFunction = (input: string) => string
  * @param deep
  */
 export function changeCase(originalAttributes: AttributesObject, caseType: CaseType, deep = false): AttributesObject {
-  const caseTypes: Record<CaseType, CaseFunction> = {
-    [CaseType.camelCase]: camelCase,
-    [CaseType.snakeCase]: snakeCase,
-    [CaseType.kebabCase]: paramCase,
-  }
-
   const caseFunction = caseTypes[caseType]
 
   if (!caseFunction) {

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -119,4 +119,48 @@ describe('deserialize', () => {
       },
     ])
   })
+
+  it('should change relationship name casing', () => {
+    const serialized: DocumentObject = {
+      data: [
+        {
+          type: 'users',
+          id: '1',
+          attributes: {
+            'first-name': 'Joe',
+            'last-name': 'Doe',
+          },
+          relationships: {
+            home_address: {
+              data: {
+                type: 'addr',
+                id: '1',
+              },
+            },
+          },
+        },
+      ],
+      included: [
+        {
+          type: 'addr',
+          id: '1',
+          attributes: {
+            street: 'Street 1',
+          },
+        },
+      ],
+    }
+
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
+      {
+        id: '1',
+        firstName: 'Joe',
+        lastName: 'Doe',
+        homeAddress: {
+          id: '1',
+          street: 'Street 1',
+        },
+      },
+    ])
+  })
 })


### PR DESCRIPTION
When deserializing with the `changeCase` option, we should change the case of relation names so they are consistent with the other properties