### PR TITLE
fix: respect `withIncluded()` when using `transform()`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -62,4 +62,5 @@ export type Options<TExtraOptions = void> = {
 
 export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
   relationships?: string[] | Record<string, string>
+  included?: boolean
 }

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -137,4 +137,56 @@ describe('serialize', () => {
       },
     })
   })
+
+  it('should serialize included when configured', () => {
+    const serialized = serialize(validEntity, 'users', {
+      relationships: { images: 'image_assets' },
+      included: true,
+    })
+
+    expect(serialized).toStrictEqual({
+      data: {
+        type: 'users',
+        attributes: {
+          address: {
+            id: 'address-1',
+          },
+          firstName: 'Joe',
+          lastName: 'Doe',
+        },
+        relationships: {
+          images: {
+            data: [
+              {
+                id: 'image-1',
+                type: 'image_assets',
+              },
+              {
+                id: 'image-2',
+                type: 'image_assets',
+              },
+            ],
+          },
+        },
+      },
+      included: [
+        {
+          id: 'image-1',
+          type: 'image_assets',
+          attributes: {
+            name: 'myimage1',
+            width: 100,
+          },
+        },
+        {
+          id: 'image-2',
+          type: 'image_assets',
+          attributes: {
+            name: 'myimage2',
+            width: 100,
+          },
+        },
+      ],
+    })
+  })
 })

--- a/tests/transformer.spec.ts
+++ b/tests/transformer.spec.ts
@@ -81,7 +81,7 @@ class UserTransformer extends Transformer<User, unknown> {
 }
 
 describe('transform', () => {
-  it('included transformation', () => {
+  it('should serialize with a custom transformer and included transformation', () => {
     const entity: User = {
       _id: 1,
       firstName: 'Joe',


### PR DESCRIPTION
Currently `withIncluded()` only works when using custom transformers. It should be possible to include using `withIncluded()` in the `transform()` call chain. Add the missing option to `serialize`.