### PR TITLE
fix: change relationship name casing when serializing

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -10,7 +10,7 @@ import {
   ResourceIdentifierObject,
   SerializeOptions,
 } from './types'
-import { whitelist, changeCase } from './utils'
+import { whitelist, changeCase, caseTypes } from './utils'
 import { JsonApiFractalError } from './errors'
 
 type IncludedRecord = Record<string, Record<string, ResourceObject>>
@@ -92,14 +92,19 @@ function serializeEntity<TEntity, TExtraOptions>(
       options,
     }
 
+    let casedRelation = relation
+    if (options.changeCase) {
+      casedRelation = caseTypes[options.changeCase](relation)
+    }
+
     if (Array.isArray(context.input)) {
-      relationships[relation] = {
+      relationships[casedRelation] = {
         data: context.input
           .map((inputItem) => serializeRelation({ ...context, input: inputItem }, includedByType))
           .filter((identifier) => !!identifier) as ResourceIdentifierObject[],
       }
     } else if (context.input) {
-      relationships[relation] = {
+      relationships[casedRelation] = {
         data: serializeRelation(context, includedByType) as ResourceIdentifierObject,
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import { camelCase, snakeCase, paramCase } from 'change-case'
+import { camelCase, snakeCase, paramCase, camelCaseTransformMerge } from 'change-case'
 import { AttributesObject, CaseType, JsonObject } from './types'
 
 type CaseFunction = (input: string) => string
 export const caseTypes: Record<CaseType, CaseFunction> = {
-  [CaseType.camelCase]: camelCase,
+  [CaseType.camelCase]: (input: string) => camelCase(input, { transform: camelCaseTransformMerge }),
   [CaseType.snakeCase]: snakeCase,
   [CaseType.kebabCase]: paramCase,
 }

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -137,4 +137,36 @@ describe('serialize', () => {
       },
     })
   })
+
+  it('should change relationship name casing', () => {
+    const serialized = serialize(
+      {
+        firstName: 'Joe',
+        lastName: 'Doe',
+        homeAddress: {
+          id: 'address-1',
+        },
+      },
+      'users',
+      { relationships: ['homeAddress'], changeCase: CaseType.snakeCase },
+    )
+
+    expect(serialized).toStrictEqual({
+      data: {
+        type: 'users',
+        attributes: {
+          first_name: 'Joe',
+          last_name: 'Doe',
+        },
+        relationships: {
+          home_address: {
+            data: {
+              type: 'homeAddress',
+              id: 'address-1',
+            },
+          },
+        },
+      },
+    })
+  })
 })

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -34,4 +34,21 @@ describe('changeCase', () => {
       ],
     })
   })
+
+  it('should remove underscores before numbers in camelCase', () => {
+    const snakeInput = {
+      first_name: 'Joe',
+      last_name: 'Doe',
+      address_1: {
+        line_1: '543 Street',
+      },
+    }
+    expect(changeCase(snakeInput, CaseType.camelCase, true)).toStrictEqual({
+      firstName: 'Joe',
+      lastName: 'Doe',
+      address1: {
+        line1: '543 Street',
+      },
+    })
+  })
 })


### PR DESCRIPTION
Respect the changeCase option when serializing relationship names. Use correct camelCase transform that handles numbers