### PR TITLE
fix: respect `withIncluded()` when using `transform()` (#34)

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -42,6 +42,7 @@ export function serialize<TEntity, TExtraOptions = unknown>(
     .withInput(data)
     .withTransformer(new DefaultTransformer(type, options.relationships || []))
     .withOptions(options)
+    .withIncluded(options.included ?? false)
     .serialize()
 }
 
@@ -54,8 +55,10 @@ function serializeContext<TEntity, TExtraOptions = unknown>(context: Context<TEn
   const includedByType: IncludedRecord = {}
 
   const data = Array.isArray(context.input)
-    ? context.input.map((entity) => serializeEntity(entity, context.transformer, context.options, includedByType))
-    : serializeEntity(context.input, context.transformer, context.options, includedByType)
+    ? context.input.map((entity) =>
+        serializeEntity(entity, context.transformer, context.included, context.options, includedByType),
+      )
+    : serializeEntity(context.input, context.transformer, context.included, context.options, includedByType)
 
   const included: ResourceObject[] = []
 
@@ -74,6 +77,7 @@ function serializeContext<TEntity, TExtraOptions = unknown>(context: Context<TEn
 function serializeEntity<TEntity, TExtraOptions>(
   entity: TEntity,
   transformer: Transformer<TEntity, TExtraOptions>,
+  included: boolean,
   options: Options<TExtraOptions>,
   includedByType: IncludedRecord,
 ): ResourceObject | NewResourceObject {
@@ -87,8 +91,11 @@ function serializeEntity<TEntity, TExtraOptions>(
   const relationships: Record<string, RelationshipObject> = {}
 
   for (const relation of Object.keys(transformer.relationships)) {
+    const relationshipContext = transformer.relationships[relation](entity, options)
     const context: Context<unknown, TExtraOptions> = {
-      ...transformer.relationships[relation](entity, options),
+      input: relationshipContext.input,
+      transformer: relationshipContext.transformer,
+      included: relationshipContext.included || included,
       options,
     }
 
@@ -161,6 +168,7 @@ function serializeRelation<TEntity = unknown, TExtraOptions = unknown>(
       includedByType[transformer.type][id] = serializeEntity(
         entity,
         transformer,
+        included,
         options,
         includedByType,
       ) as ResourceObject

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,4 +62,5 @@ export type Options<TExtraOptions = void> = {
 
 export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
   relationships?: string[] | Record<string, string>
+  included?: boolean
 }

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -169,4 +169,56 @@ describe('serialize', () => {
       },
     })
   })
+
+  it('should serialize included when configured', () => {
+    const serialized = serialize(validEntity, 'users', {
+      relationships: { images: 'image_assets' },
+      included: true,
+    })
+
+    expect(serialized).toStrictEqual({
+      data: {
+        type: 'users',
+        attributes: {
+          address: {
+            id: 'address-1',
+          },
+          firstName: 'Joe',
+          lastName: 'Doe',
+        },
+        relationships: {
+          images: {
+            data: [
+              {
+                id: 'image-1',
+                type: 'image_assets',
+              },
+              {
+                id: 'image-2',
+                type: 'image_assets',
+              },
+            ],
+          },
+        },
+      },
+      included: [
+        {
+          id: 'image-1',
+          type: 'image_assets',
+          attributes: {
+            name: 'myimage1',
+            width: 100,
+          },
+        },
+        {
+          id: 'image-2',
+          type: 'image_assets',
+          attributes: {
+            name: 'myimage2',
+            width: 100,
+          },
+        },
+      ],
+    })
+  })
 })

--- a/tests/transformer.spec.ts
+++ b/tests/transformer.spec.ts
@@ -81,7 +81,7 @@ class UserTransformer extends Transformer<User, unknown> {
 }
 
 describe('transform', () => {
-  it('included transformation', () => {
+  it('should serialize with a custom transformer and included transformation', () => {
     const entity: User = {
       _id: 1,
       firstName: 'Joe',


### PR DESCRIPTION
Currently `withIncluded()` only works when using custom transformers. It should be possible to include using `withIncluded()` in the `transform()` call chain. Add the missing option to `serialize`.