### PR TITLE
feat: add Symbol(type) in deserialization

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -26,6 +26,8 @@ export function deserialize<TEntity, TExtraOptions = unknown>(
     : parseJsonApiSimpleResourceData(response.data, included, options, false, {})
 }
 
+export const typeField = Symbol('type')
+
 function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   data: ResourceObject,
   included: ExistingResourceObject[],
@@ -50,6 +52,7 @@ function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   }
 
   const resource: Record<string, unknown> = {
+    [typeField]: data.type,
     ...(id ? { id } : {}),
     ...attributes,
   }
@@ -118,7 +121,7 @@ function findJsonApiIncluded<TEntity, TExtraOptions>(
   const foundResource = included.find((item) => item.type === type && item.id === id)
 
   if (!foundResource) {
-    return { id } as unknown as TEntity
+    return { id, [typeField]: type } as unknown as TEntity
   }
 
   return parseJsonApiSimpleResourceData(foundResource, included, options, true, includedCache)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
 export * from './types'
 export { DefaultTransformer } from './default-transformer'
 export { Context, ContextBuilder } from './context'
-export { deserialize } from './deserializer'
+export { deserialize, typeField } from './deserializer'
 export { serialize, transform } from './serializer'
 export { whitelist } from './utils'
 export { JsonApiFractalError } from './errors'

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -1,4 +1,4 @@
-import { deserialize, DocumentObject } from '../src'
+import { deserialize, typeField, DocumentObject } from '../src'
 import { CaseType } from '../src/types'
 
 describe('deserialize', () => {
@@ -42,13 +42,18 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         address: {
           id: '1',
+          [typeField]: 'addr',
           street: 'Street 1',
         },
-        images: [{ id: '1' }, { id: '2' }],
+        images: [
+          { id: '1', [typeField]: 'img' },
+          { id: '2', [typeField]: 'img' },
+        ],
       },
     ])
   })
@@ -101,6 +106,7 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         links: {
@@ -109,13 +115,17 @@ describe('deserialize', () => {
         },
         address: {
           id: '1',
+          [typeField]: 'addr',
           street: 'Street 1',
           links: {
             self: 'https://example.org/address/1/relationships/address',
             related: 'https://example.org/address/1',
           },
         },
-        images: [{ id: '1' }, { id: '2' }],
+        images: [
+          { id: '1', [typeField]: 'img' },
+          { id: '2', [typeField]: 'img' },
+        ],
       },
     ])
   })
@@ -154,10 +164,12 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         homeAddress: {
           id: '1',
+          [typeField]: 'addr',
           street: 'Street 1',
         },
       },


### PR DESCRIPTION
Fix https://github.com/andersondanilo/jsonapi-fractal/issues/138

Add `Symbol('type')` to include all types during deserialization