### PR TITLE
feat: add `typeKey`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,6 @@ jsonapi-fractal
 
 - [AttributesObject](README.md#attributesobject)
 - [Context](README.md#context)
-- [DeserializeOptions](README.md#deserializeoptions)
 - [DocumentObject](README.md#documentobject)
 - [ExistingDocumentObject](README.md#existingdocumentobject)
 - [ExistingResourceObject](README.md#existingresourceobject)
@@ -71,7 +70,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:17](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L17)
+[src/types.ts:17](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L17)
 
 ---
 
@@ -97,23 +96,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/context.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L5)
-
----
-
-### DeserializeOptions
-
-Ƭ **DeserializeOptions**<`TExtraOptions`\>: [`Options`](README.md#options)<`TExtraOptions`\> & { `typeKey?`: `string` }
-
-#### Type parameters
-
-| Name            | Type   |
-| :-------------- | :----- |
-| `TExtraOptions` | `void` |
-
-#### Defined in
-
-[src/types.ts:64](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L64)
+[src/context.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L5)
 
 ---
 
@@ -123,7 +106,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L15)
+[src/types.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L15)
 
 ---
 
@@ -133,7 +116,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:11](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L11)
+[src/types.ts:11](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L11)
 
 ---
 
@@ -143,7 +126,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L28)
+[src/types.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L28)
 
 ---
 
@@ -153,7 +136,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L21)
+[src/types.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L21)
 
 ---
 
@@ -163,7 +146,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L19)
+[src/types.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L19)
 
 ---
 
@@ -173,7 +156,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L13)
+[src/types.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L13)
 
 ---
 
@@ -183,7 +166,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:35](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L35)
+[src/types.ts:35](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L35)
 
 ---
 
@@ -206,10 +189,11 @@ node_modules/type-fest/source/basic.d.ts:45
 | `extra?`          | `TExtraOptions`                 | custom properties, that are available in the transformer                                  |
 | `fields?`         | `Record`<`string`, `string`[]\> | map of EntityType => Fields Array, e.g. `{"users": ["name", "age"], "images": ["width"]}` |
 | `idKey?`          | `string`                        | key that should be used as the id                                                         |
+| `typeKey?`        | `string`                        | key that should be used as the type                                                       |
 
 #### Defined in
 
-[src/types.ts:50](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L50)
+[src/types.ts:50](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L50)
 
 ---
 
@@ -226,7 +210,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:39](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L39)
+[src/types.ts:39](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L39)
 
 ---
 
@@ -251,7 +235,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/transformer.ts:24](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L24)
+[src/transformer.ts:24](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L24)
 
 ---
 
@@ -283,7 +267,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/transformer.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L19)
+[src/transformer.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L19)
 
 ---
 
@@ -300,7 +284,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:23](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L23)
+[src/types.ts:23](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L23)
 
 ---
 
@@ -310,7 +294,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L37)
+[src/types.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L37)
 
 ---
 
@@ -326,7 +310,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:69](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L69)
+[src/types.ts:66](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L66)
 
 ---
 
@@ -343,7 +327,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/transformer.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L14)
+[src/transformer.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L14)
 
 ## Functions
 
@@ -362,10 +346,10 @@ Deserialize a JSON:API response
 
 #### Parameters
 
-| Name       | Type                                                                   |
-| :--------- | :--------------------------------------------------------------------- |
-| `response` | [`DocumentObject`](README.md#documentobject)                           |
-| `options`  | [`DeserializeOptions`](README.md#deserializeoptions)<`TExtraOptions`\> |
+| Name       | Type                                             |
+| :--------- | :----------------------------------------------- |
+| `response` | [`DocumentObject`](README.md#documentobject)     |
+| `options`  | [`Options`](README.md#options)<`TExtraOptions`\> |
 
 #### Returns
 
@@ -373,7 +357,7 @@ Deserialize a JSON:API response
 
 #### Defined in
 
-[src/deserializer.ts:12](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/deserializer.ts#L12)
+[src/deserializer.ts:12](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/deserializer.ts#L12)
 
 ---
 
@@ -404,7 +388,7 @@ Serialize the entity
 
 #### Defined in
 
-[src/serializer.ts:32](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/serializer.ts#L32)
+[src/serializer.ts:32](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/serializer.ts#L32)
 
 ---
 
@@ -427,7 +411,7 @@ Create a ContextBuilder, used to configure the transformation
 
 #### Defined in
 
-[src/serializer.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/serializer.ts#L21)
+[src/serializer.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/serializer.ts#L21)
 
 ---
 
@@ -450,4 +434,4 @@ Keep only a set of fields on a given object
 
 #### Defined in
 
-[src/utils.ts:54](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/utils.ts#L54)
+[src/utils.ts:54](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/utils.ts#L54)

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ jsonapi-fractal
 
 - [AttributesObject](README.md#attributesobject)
 - [Context](README.md#context)
+- [DeserializeOptions](README.md#deserializeoptions)
 - [DocumentObject](README.md#documentobject)
 - [ExistingDocumentObject](README.md#existingdocumentobject)
 - [ExistingResourceObject](README.md#existingresourceobject)
@@ -38,6 +39,10 @@ jsonapi-fractal
 - [ResourceObject](README.md#resourceobject)
 - [SerializeOptions](README.md#serializeoptions)
 - [TransformerRelationships](README.md#transformerrelationships)
+
+### Variables
+
+- [typeField](README.md#typefield)
 
 ### Functions
 
@@ -58,9 +63,9 @@ This type can be useful to enforce some input to be JSON-compatible or as a supe
 
 #### Defined in
 
-node_modules/type-fest/source/basic.d.ts:22
+node_modules/type-fest/source/basic.d.ts:45
 
-___
+---
 
 ## Other Type Aliases
 
@@ -70,9 +75,9 @@ ___
 
 #### Defined in
 
-[src/types.ts:17](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L17)
+[src/types.ts:17](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L17)
 
-___
+---
 
 ### Context
 
@@ -80,25 +85,41 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `TEntity` |
+| Name               | Type      |
+| :----------------- | :-------- |
+| `TEntity`          | `TEntity` |
 | `TExtraProperties` | `unknown` |
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `included` | `boolean` |
-| `input` | `TEntity` \| `undefined` |
-| `options` | [`Options`](README.md#options)<`TExtraProperties`\> |
+| Name          | Type                                                                    |
+| :------------ | :---------------------------------------------------------------------- |
+| `included`    | `boolean`                                                               |
+| `input`       | `TEntity` \| `undefined`                                                |
+| `options`     | [`Options`](README.md#options)<`TExtraProperties`\>                     |
 | `transformer` | [`Transformer`](classes/Transformer.md)<`TEntity`, `TExtraProperties`\> |
 
 #### Defined in
 
-[src/context.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L5)
+[src/context.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L5)
 
-___
+---
+
+### DeserializeOptions
+
+Ƭ **DeserializeOptions**<`TExtraOptions`\>: [`Options`](README.md#options)<`TExtraOptions`\> & { `injectType?`: `boolean` }
+
+#### Type parameters
+
+| Name            | Type   |
+| :-------------- | :----- |
+| `TExtraOptions` | `void` |
+
+#### Defined in
+
+[src/types.ts:64](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L64)
+
+---
 
 ### DocumentObject
 
@@ -106,9 +127,9 @@ ___
 
 #### Defined in
 
-[src/types.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L15)
+[src/types.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L15)
 
-___
+---
 
 ### ExistingDocumentObject
 
@@ -116,19 +137,19 @@ ___
 
 #### Defined in
 
-[src/types.ts:11](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L11)
+[src/types.ts:11](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L11)
 
-___
+---
 
 ### ExistingResourceObject
 
-Ƭ **ExistingResourceObject**: [`ResourceIdentifierObject`](README.md#resourceidentifierobject) & { `attributes`: [`AttributesObject`](README.md#attributesobject) ; `id`: `string` ; `links?`: [`LinkObject`](README.md#linkobject) ; `relationships?`: `Record`<`string`, [`RelationshipObject`](README.md#relationshipobject)\>  }
+Ƭ **ExistingResourceObject**: [`ResourceIdentifierObject`](README.md#resourceidentifierobject) & { `attributes`: [`AttributesObject`](README.md#attributesobject) ; `id`: `string` ; `links?`: [`LinkObject`](README.md#linkobject) ; `relationships?`: `Record`<`string`, [`RelationshipObject`](README.md#relationshipobject)\> }
 
 #### Defined in
 
-[src/types.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L28)
+[src/types.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L28)
 
-___
+---
 
 ### LinkObject
 
@@ -136,9 +157,9 @@ ___
 
 #### Defined in
 
-[src/types.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L21)
+[src/types.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L21)
 
-___
+---
 
 ### MetaObject
 
@@ -146,9 +167,9 @@ ___
 
 #### Defined in
 
-[src/types.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L19)
+[src/types.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L19)
 
-___
+---
 
 ### NewDocumentObject
 
@@ -156,19 +177,19 @@ ___
 
 #### Defined in
 
-[src/types.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L13)
+[src/types.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L13)
 
-___
+---
 
 ### NewResourceObject
 
-Ƭ **NewResourceObject**: `Omit`<[`ExistingResourceObject`](README.md#existingresourceobject), ``"id"``\>
+Ƭ **NewResourceObject**: `Omit`<[`ExistingResourceObject`](README.md#existingresourceobject), `"id"`\>
 
 #### Defined in
 
-[src/types.ts:35](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L35)
+[src/types.ts:35](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L35)
 
-___
+---
 
 ### Options
 
@@ -176,25 +197,25 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name            | Type   |
+| :-------------- | :----- |
 | `TExtraOptions` | `void` |
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `changeCase?` | [`CaseType`](enums/CaseType.md) | change case of the attribute keys |
-| `changeCaseDeep?` | `boolean` | if true, also apply the change for sub objects |
-| `extra?` | `TExtraOptions` | custom properties, that are available in the transformer |
-| `fields?` | `Record`<`string`, `string`[]\> | map of EntityType => Fields Array, e.g. `{"users": ["name", "age"], "images": ["width"]}` |
-| `idKey?` | `string` | key that should be used as the id |
+| Name              | Type                            | Description                                                                               |
+| :---------------- | :------------------------------ | :---------------------------------------------------------------------------------------- |
+| `changeCase?`     | [`CaseType`](enums/CaseType.md) | change case of the attribute keys                                                         |
+| `changeCaseDeep?` | `boolean`                       | if true, also apply the change for sub objects                                            |
+| `extra?`          | `TExtraOptions`                 | custom properties, that are available in the transformer                                  |
+| `fields?`         | `Record`<`string`, `string`[]\> | map of EntityType => Fields Array, e.g. `{"users": ["name", "age"], "images": ["width"]}` |
+| `idKey?`          | `string`                        | key that should be used as the id                                                         |
 
 #### Defined in
 
-[src/types.ts:50](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L50)
+[src/types.ts:50](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L50)
 
-___
+---
 
 ### RelationshipObject
 
@@ -202,16 +223,16 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `data` | [`ResourceIdentifierObject`](README.md#resourceidentifierobject) \| [`ResourceIdentifierObject`](README.md#resourceidentifierobject)[] |
-| `links?` | [`LinkObject`](README.md#linkobject) |
+| Name     | Type                                                                                                                                   |
+| :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`   | [`ResourceIdentifierObject`](README.md#resourceidentifierobject) \| [`ResourceIdentifierObject`](README.md#resourceidentifierobject)[] |
+| `links?` | [`LinkObject`](README.md#linkobject)                                                                                                   |
 
 #### Defined in
 
-[src/types.ts:39](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L39)
+[src/types.ts:39](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L39)
 
-___
+---
 
 ### RelationshipTransformerInfo
 
@@ -219,24 +240,24 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name            | Type            |
+| :-------------- | :-------------- |
 | `TExtraOptions` | `TExtraOptions` |
-| `T` | `unknown` |
+| `T`             | `unknown`       |
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `included` | `boolean` |
-| `input` | `T` |
+| Name          | Type                                                           |
+| :------------ | :------------------------------------------------------------- |
+| `included`    | `boolean`                                                      |
+| `input`       | `T`                                                            |
 | `transformer` | [`Transformer`](classes/Transformer.md)<`T`, `TExtraOptions`\> |
 
 #### Defined in
 
-[src/transformer.ts:24](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L24)
+[src/transformer.ts:24](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L24)
 
-___
+---
 
 ### RelationshipTransformerInfoFunction
 
@@ -244,9 +265,9 @@ ___
 
 #### Type parameters
 
-| Name |
-| :------ |
-| `TEntity` |
+| Name            |
+| :-------------- |
+| `TEntity`       |
 | `TExtraOptions` |
 
 #### Type declaration
@@ -255,9 +276,9 @@ ___
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `entity` | `TEntity` |
+| Name      | Type                                             |
+| :-------- | :----------------------------------------------- |
+| `entity`  | `TEntity`                                        |
 | `options` | [`Options`](README.md#options)<`TExtraOptions`\> |
 
 ##### Returns
@@ -266,9 +287,9 @@ ___
 
 #### Defined in
 
-[src/transformer.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L19)
+[src/transformer.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L19)
 
-___
+---
 
 ### ResourceIdentifierObject
 
@@ -276,16 +297,16 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `id` | `string` |
+| Name   | Type     |
+| :----- | :------- |
+| `id`   | `string` |
 | `type` | `string` |
 
 #### Defined in
 
-[src/types.ts:23](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L23)
+[src/types.ts:23](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L23)
 
-___
+---
 
 ### ResourceObject
 
@@ -293,25 +314,25 @@ ___
 
 #### Defined in
 
-[src/types.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L37)
+[src/types.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L37)
 
-___
+---
 
 ### SerializeOptions
 
-Ƭ **SerializeOptions**<`TExtraOptions`\>: [`Options`](README.md#options)<`TExtraOptions`\> & { `included?`: `boolean` ; `relationships?`: `string`[] \| `Record`<`string`, `string`\>  }
+Ƭ **SerializeOptions**<`TExtraOptions`\>: [`Options`](README.md#options)<`TExtraOptions`\> & { `included?`: `boolean` ; `relationships?`: `string`[] \| `Record`<`string`, `string`\> }
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name            | Type   |
+| :-------------- | :----- |
 | `TExtraOptions` | `void` |
 
 #### Defined in
 
-[src/types.ts:63](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L63)
+[src/types.ts:69](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L69)
 
-___
+---
 
 ### TransformerRelationships
 
@@ -319,14 +340,24 @@ ___
 
 #### Type parameters
 
-| Name |
-| :------ |
-| `TEntity` |
+| Name            |
+| :-------------- |
+| `TEntity`       |
 | `TExtraOptions` |
 
 #### Defined in
 
-[src/transformer.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L14)
+[src/transformer.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L14)
+
+## Variables
+
+### typeField
+
+• `Const` **typeField**: typeof [`typeField`](README.md#typefield)
+
+#### Defined in
+
+[src/deserializer.ts:29](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/deserializer.ts#L29)
 
 ## Functions
 
@@ -338,17 +369,17 @@ Deserialize a JSON:API response
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `TEntity` |
+| Name            | Type      |
+| :-------------- | :-------- |
+| `TEntity`       | `TEntity` |
 | `TExtraOptions` | `unknown` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `response` | [`DocumentObject`](README.md#documentobject) |
-| `options` | [`Options`](README.md#options)<`TExtraOptions`\> |
+| Name       | Type                                                                   |
+| :--------- | :--------------------------------------------------------------------- |
+| `response` | [`DocumentObject`](README.md#documentobject)                           |
+| `options`  | [`DeserializeOptions`](README.md#deserializeoptions)<`TExtraOptions`\> |
 
 #### Returns
 
@@ -356,9 +387,9 @@ Deserialize a JSON:API response
 
 #### Defined in
 
-[src/deserializer.ts:12](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/deserializer.ts#L12)
+[src/deserializer.ts:12](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/deserializer.ts#L12)
 
-___
+---
 
 ### serialize
 
@@ -368,17 +399,17 @@ Serialize the entity
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `TEntity` |
+| Name            | Type      |
+| :-------------- | :-------- |
+| `TEntity`       | `TEntity` |
 | `TExtraOptions` | `unknown` |
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `data` | `TEntity` | entity to be serialized |
-| `type` | `string` | type of the entity |
+| Name       | Type                                                               | Description                       |
+| :--------- | :----------------------------------------------------------------- | :-------------------------------- |
+| `data`     | `TEntity`                                                          | entity to be serialized           |
+| `type`     | `string`                                                           | type of the entity                |
 | `options?` | [`SerializeOptions`](README.md#serializeoptions)<`TExtraOptions`\> | options used in the serialization |
 
 #### Returns
@@ -387,9 +418,9 @@ Serialize the entity
 
 #### Defined in
 
-[src/serializer.ts:32](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/serializer.ts#L32)
+[src/serializer.ts:32](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/serializer.ts#L32)
 
-___
+---
 
 ### transform
 
@@ -399,9 +430,9 @@ Create a ContextBuilder, used to configure the transformation
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `TEntity` |
+| Name            | Type      |
+| :-------------- | :-------- |
+| `TEntity`       | `TEntity` |
 | `TExtraOptions` | `unknown` |
 
 #### Returns
@@ -410,9 +441,9 @@ Create a ContextBuilder, used to configure the transformation
 
 #### Defined in
 
-[src/serializer.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/serializer.ts#L21)
+[src/serializer.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/serializer.ts#L21)
 
-___
+---
 
 ### whitelist
 
@@ -422,10 +453,10 @@ Keep only a set of fields on a given object
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `object` | `unknown` |
-| `list` | `string`[] |
+| Name     | Type       |
+| :------- | :--------- |
+| `object` | `unknown`  |
+| `list`   | `string`[] |
 
 #### Returns
 
@@ -433,4 +464,4 @@ Keep only a set of fields on a given object
 
 #### Defined in
 
-[src/utils.ts:54](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/utils.ts#L54)
+[src/utils.ts:54](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/utils.ts#L54)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,11 +15,11 @@ jsonapi-fractal
 - [JsonApiFractalError](classes/JsonApiFractalError.md)
 - [Transformer](classes/Transformer.md)
 
-### JSON Type Aliases
+### JSON Type aliases
 
 - [JsonObject](README.md#jsonobject)
 
-### Other Type Aliases
+### Other Type aliases
 
 - [AttributesObject](README.md#attributesobject)
 - [Context](README.md#context)
@@ -40,10 +40,6 @@ jsonapi-fractal
 - [SerializeOptions](README.md#serializeoptions)
 - [TransformerRelationships](README.md#transformerrelationships)
 
-### Variables
-
-- [typeField](README.md#typefield)
-
 ### Functions
 
 - [deserialize](README.md#deserialize)
@@ -51,7 +47,7 @@ jsonapi-fractal
 - [transform](README.md#transform)
 - [whitelist](README.md#whitelist)
 
-## JSON Type Aliases
+## JSON Type aliases
 
 ### JsonObject
 
@@ -67,7 +63,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 ---
 
-## Other Type Aliases
+## Other Type aliases
 
 ### AttributesObject
 
@@ -75,7 +71,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:17](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L17)
+[src/types.ts:17](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L17)
 
 ---
 
@@ -101,13 +97,13 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/context.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L5)
+[src/context.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L5)
 
 ---
 
 ### DeserializeOptions
 
-Ƭ **DeserializeOptions**<`TExtraOptions`\>: [`Options`](README.md#options)<`TExtraOptions`\> & { `injectType?`: `boolean` }
+Ƭ **DeserializeOptions**<`TExtraOptions`\>: [`Options`](README.md#options)<`TExtraOptions`\> & { `typeKey?`: `string` }
 
 #### Type parameters
 
@@ -117,7 +113,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:64](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L64)
+[src/types.ts:64](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L64)
 
 ---
 
@@ -127,7 +123,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L15)
+[src/types.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L15)
 
 ---
 
@@ -137,7 +133,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:11](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L11)
+[src/types.ts:11](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L11)
 
 ---
 
@@ -147,7 +143,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L28)
+[src/types.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L28)
 
 ---
 
@@ -157,7 +153,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L21)
+[src/types.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L21)
 
 ---
 
@@ -167,7 +163,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L19)
+[src/types.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L19)
 
 ---
 
@@ -177,7 +173,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L13)
+[src/types.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L13)
 
 ---
 
@@ -187,7 +183,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:35](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L35)
+[src/types.ts:35](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L35)
 
 ---
 
@@ -213,7 +209,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:50](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L50)
+[src/types.ts:50](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L50)
 
 ---
 
@@ -230,7 +226,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:39](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L39)
+[src/types.ts:39](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L39)
 
 ---
 
@@ -255,7 +251,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/transformer.ts:24](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L24)
+[src/transformer.ts:24](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L24)
 
 ---
 
@@ -287,7 +283,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/transformer.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L19)
+[src/transformer.ts:19](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L19)
 
 ---
 
@@ -304,7 +300,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:23](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L23)
+[src/types.ts:23](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L23)
 
 ---
 
@@ -314,7 +310,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L37)
+[src/types.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L37)
 
 ---
 
@@ -330,7 +326,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/types.ts:69](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/types.ts#L69)
+[src/types.ts:69](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L69)
 
 ---
 
@@ -347,17 +343,7 @@ node_modules/type-fest/source/basic.d.ts:45
 
 #### Defined in
 
-[src/transformer.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L14)
-
-## Variables
-
-### typeField
-
-• `Const` **typeField**: typeof [`typeField`](README.md#typefield)
-
-#### Defined in
-
-[src/deserializer.ts:29](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/deserializer.ts#L29)
+[src/transformer.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L14)
 
 ## Functions
 
@@ -387,7 +373,7 @@ Deserialize a JSON:API response
 
 #### Defined in
 
-[src/deserializer.ts:12](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/deserializer.ts#L12)
+[src/deserializer.ts:12](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/deserializer.ts#L12)
 
 ---
 
@@ -418,7 +404,7 @@ Serialize the entity
 
 #### Defined in
 
-[src/serializer.ts:32](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/serializer.ts#L32)
+[src/serializer.ts:32](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/serializer.ts#L32)
 
 ---
 
@@ -441,7 +427,7 @@ Create a ContextBuilder, used to configure the transformation
 
 #### Defined in
 
-[src/serializer.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/serializer.ts#L21)
+[src/serializer.ts:21](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/serializer.ts#L21)
 
 ---
 
@@ -464,4 +450,4 @@ Keep only a set of fields on a given object
 
 #### Defined in
 
-[src/utils.ts:54](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/utils.ts#L54)
+[src/utils.ts:54](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/utils.ts#L54)

--- a/docs/classes/ContextBuilder.md
+++ b/docs/classes/ContextBuilder.md
@@ -4,9 +4,9 @@
 
 ## Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `TEntity` |
+| Name               | Type      |
+| :----------------- | :-------- |
+| `TEntity`          | `TEntity` |
 | `TExtraProperties` | `unknown` |
 
 ## Table of contents
@@ -40,20 +40,20 @@
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `TEntity` |
+| Name               | Type      |
+| :----------------- | :-------- |
+| `TEntity`          | `TEntity` |
 | `TExtraProperties` | `unknown` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name             | Type                                                                                                                        |
+| :--------------- | :-------------------------------------------------------------------------------------------------------------------------- |
 | `renderFunction` | (`c`: [`Context`](../README.md#context)<`TEntity`, `TExtraProperties`\>) => [`DocumentObject`](../README.md#documentobject) |
 
 #### Defined in
 
-[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L18)
+[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L18)
 
 ## Properties
 
@@ -63,9 +63,9 @@
 
 #### Defined in
 
-[src/context.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L15)
+[src/context.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L15)
 
-___
+---
 
 ### input
 
@@ -73,9 +73,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L13)
+[src/context.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L13)
 
-___
+---
 
 ### options
 
@@ -83,9 +83,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:16](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L16)
+[src/context.ts:16](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L16)
 
-___
+---
 
 ### renderFunction
 
@@ -97,19 +97,15 @@ ___
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `c` | [`Context`](../README.md#context)<`TEntity`, `TExtraProperties`\> |
+| Name | Type                                                              |
+| :--- | :---------------------------------------------------------------- |
+| `c`  | [`Context`](../README.md#context)<`TEntity`, `TExtraProperties`\> |
 
 ##### Returns
 
 [`DocumentObject`](../README.md#documentobject)
 
-#### Defined in
-
-[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L18)
-
-___
+---
 
 ### transformer
 
@@ -117,7 +113,7 @@ ___
 
 #### Defined in
 
-[src/context.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L14)
+[src/context.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L14)
 
 ## Methods
 
@@ -131,9 +127,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:60](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L60)
+[src/context.ts:60](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L60)
 
-___
+---
 
 ### toContext
 
@@ -145,9 +141,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:43](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L43)
+[src/context.ts:43](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L43)
 
-___
+---
 
 ### withIncluded
 
@@ -155,8 +151,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name       | Type      |
+| :--------- | :-------- |
 | `included` | `boolean` |
 
 #### Returns
@@ -165,9 +161,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:31](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L31)
+[src/context.ts:31](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L31)
 
-___
+---
 
 ### withInput
 
@@ -175,8 +171,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type      |
+| :------ | :-------- |
 | `input` | `TEntity` |
 
 #### Returns
@@ -185,9 +181,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:20](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L20)
+[src/context.ts:20](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L20)
 
-___
+---
 
 ### withOptions
 
@@ -195,8 +191,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type                                                   |
+| :-------- | :----------------------------------------------------- |
 | `options` | [`Options`](../README.md#options)<`TExtraProperties`\> |
 
 #### Returns
@@ -205,9 +201,9 @@ ___
 
 #### Defined in
 
-[src/context.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L37)
+[src/context.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L37)
 
-___
+---
 
 ### withTransformer
 
@@ -215,8 +211,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name          | Type                                                            |
+| :------------ | :-------------------------------------------------------------- |
 | `transformer` | [`Transformer`](Transformer.md)<`TEntity`, `TExtraProperties`\> |
 
 #### Returns
@@ -225,4 +221,4 @@ ___
 
 #### Defined in
 
-[src/context.ts:25](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/context.ts#L25)
+[src/context.ts:25](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L25)

--- a/docs/classes/ContextBuilder.md
+++ b/docs/classes/ContextBuilder.md
@@ -53,7 +53,7 @@
 
 #### Defined in
 
-[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L18)
+[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L18)
 
 ## Properties
 
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[src/context.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L15)
+[src/context.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L15)
 
 ---
 
@@ -73,7 +73,7 @@
 
 #### Defined in
 
-[src/context.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L13)
+[src/context.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L13)
 
 ---
 
@@ -83,7 +83,7 @@
 
 #### Defined in
 
-[src/context.ts:16](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L16)
+[src/context.ts:16](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L16)
 
 ---
 
@@ -113,7 +113,7 @@
 
 #### Defined in
 
-[src/context.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L14)
+[src/context.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L14)
 
 ## Methods
 
@@ -127,7 +127,7 @@
 
 #### Defined in
 
-[src/context.ts:60](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L60)
+[src/context.ts:60](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L60)
 
 ---
 
@@ -141,7 +141,7 @@
 
 #### Defined in
 
-[src/context.ts:43](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L43)
+[src/context.ts:43](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L43)
 
 ---
 
@@ -161,7 +161,7 @@
 
 #### Defined in
 
-[src/context.ts:31](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L31)
+[src/context.ts:31](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L31)
 
 ---
 
@@ -181,7 +181,7 @@
 
 #### Defined in
 
-[src/context.ts:20](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L20)
+[src/context.ts:20](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L20)
 
 ---
 
@@ -201,7 +201,7 @@
 
 #### Defined in
 
-[src/context.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L37)
+[src/context.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L37)
 
 ---
 
@@ -221,4 +221,4 @@
 
 #### Defined in
 
-[src/context.ts:25](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/context.ts#L25)
+[src/context.ts:25](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L25)

--- a/docs/classes/ContextBuilder.md
+++ b/docs/classes/ContextBuilder.md
@@ -53,7 +53,7 @@
 
 #### Defined in
 
-[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L18)
+[src/context.ts:18](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L18)
 
 ## Properties
 
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[src/context.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L15)
+[src/context.ts:15](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L15)
 
 ---
 
@@ -73,7 +73,7 @@
 
 #### Defined in
 
-[src/context.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L13)
+[src/context.ts:13](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L13)
 
 ---
 
@@ -83,7 +83,7 @@
 
 #### Defined in
 
-[src/context.ts:16](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L16)
+[src/context.ts:16](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L16)
 
 ---
 
@@ -113,7 +113,7 @@
 
 #### Defined in
 
-[src/context.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L14)
+[src/context.ts:14](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L14)
 
 ## Methods
 
@@ -127,7 +127,7 @@
 
 #### Defined in
 
-[src/context.ts:60](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L60)
+[src/context.ts:60](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L60)
 
 ---
 
@@ -141,7 +141,7 @@
 
 #### Defined in
 
-[src/context.ts:43](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L43)
+[src/context.ts:43](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L43)
 
 ---
 
@@ -161,7 +161,7 @@
 
 #### Defined in
 
-[src/context.ts:31](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L31)
+[src/context.ts:31](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L31)
 
 ---
 
@@ -181,7 +181,7 @@
 
 #### Defined in
 
-[src/context.ts:20](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L20)
+[src/context.ts:20](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L20)
 
 ---
 
@@ -201,7 +201,7 @@
 
 #### Defined in
 
-[src/context.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L37)
+[src/context.ts:37](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L37)
 
 ---
 
@@ -221,4 +221,4 @@
 
 #### Defined in
 
-[src/context.ts:25](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/context.ts#L25)
+[src/context.ts:25](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/context.ts#L25)

--- a/docs/classes/DefaultTransformer.md
+++ b/docs/classes/DefaultTransformer.md
@@ -56,7 +56,7 @@
 
 #### Defined in
 
-[src/default-transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/default-transformer.ts#L8)
+[src/default-transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/default-transformer.ts#L8)
 
 ## Properties
 
@@ -70,7 +70,7 @@
 
 #### Defined in
 
-[src/default-transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/default-transformer.ts#L6)
+[src/default-transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/default-transformer.ts#L6)
 
 ---
 
@@ -104,4 +104,4 @@
 
 #### Defined in
 
-[src/default-transformer.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/default-transformer.ts#L28)
+[src/default-transformer.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/default-transformer.ts#L28)

--- a/docs/classes/DefaultTransformer.md
+++ b/docs/classes/DefaultTransformer.md
@@ -23,6 +23,7 @@
 
 ### Properties
 
+- [options](DefaultTransformer.md#options)
 - [relationships](DefaultTransformer.md#relationships)
 - [type](DefaultTransformer.md#type)
 
@@ -56,9 +57,19 @@
 
 #### Defined in
 
-[src/default-transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/default-transformer.ts#L8)
+[src/default-transformer.ts:9](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/default-transformer.ts#L9)
 
 ## Properties
+
+### options
+
+• `Optional` `Readonly` **options**: [`Options`](../README.md#options)<`TExtraOptions`\>
+
+#### Defined in
+
+[src/default-transformer.ts:7](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/default-transformer.ts#L7)
+
+---
 
 ### relationships
 
@@ -70,7 +81,7 @@
 
 #### Defined in
 
-[src/default-transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/default-transformer.ts#L6)
+[src/default-transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/default-transformer.ts#L6)
 
 ---
 
@@ -104,4 +115,4 @@
 
 #### Defined in
 
-[src/default-transformer.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/default-transformer.ts#L28)
+[src/default-transformer.ts:29](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/default-transformer.ts#L29)

--- a/docs/classes/DefaultTransformer.md
+++ b/docs/classes/DefaultTransformer.md
@@ -4,10 +4,10 @@
 
 ## Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `unknown` |
-| `TExtraOptions` | `void` |
+| Name            | Type      |
+| :-------------- | :-------- |
+| `TEntity`       | `unknown` |
+| `TExtraOptions` | `void`    |
 
 ## Hierarchy
 
@@ -38,17 +38,17 @@
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `TEntity` | `unknown` |
-| `TExtraOptions` | `void` |
+| Name            | Type      |
+| :-------------- | :-------- |
+| `TEntity`       | `unknown` |
+| `TExtraOptions` | `void`    |
 
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `type` | `string` | `undefined` |
-| `relationships` | `string`[] \| `Record`<`string`, `string`\> | `[]` |
+| Name            | Type                                        | Default value |
+| :-------------- | :------------------------------------------ | :------------ |
+| `type`          | `string`                                    | `undefined`   |
+| `relationships` | `string`[] \| `Record`<`string`, `string`\> | `[]`          |
 
 #### Overrides
 
@@ -56,7 +56,7 @@
 
 #### Defined in
 
-[src/default-transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/default-transformer.ts#L8)
+[src/default-transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/default-transformer.ts#L8)
 
 ## Properties
 
@@ -70,9 +70,9 @@
 
 #### Defined in
 
-[src/default-transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/default-transformer.ts#L6)
+[src/default-transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/default-transformer.ts#L6)
 
-___
+---
 
 ### type
 
@@ -82,10 +82,6 @@ ___
 
 [Transformer](Transformer.md).[type](Transformer.md#type)
 
-#### Defined in
-
-[src/default-transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/default-transformer.ts#L8)
-
 ## Methods
 
 ### transform
@@ -94,8 +90,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type  |
+| :------- | :---- |
 | `entity` | `any` |
 
 #### Returns
@@ -108,4 +104,4 @@ ___
 
 #### Defined in
 
-[src/default-transformer.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/default-transformer.ts#L28)
+[src/default-transformer.ts:28](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/default-transformer.ts#L28)

--- a/docs/classes/JsonApiFractalError.md
+++ b/docs/classes/JsonApiFractalError.md
@@ -44,7 +44,7 @@ Error.constructor
 
 #### Defined in
 
-[src/errors.ts:2](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/errors.ts#L2)
+[src/errors.ts:2](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/errors.ts#L2)
 
 ## Properties
 

--- a/docs/classes/JsonApiFractalError.md
+++ b/docs/classes/JsonApiFractalError.md
@@ -34,8 +34,8 @@
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type     |
+| :-------- | :------- |
 | `message` | `string` |
 
 #### Overrides
@@ -44,7 +44,7 @@ Error.constructor
 
 #### Defined in
 
-[src/errors.ts:2](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/errors.ts#L2)
+[src/errors.ts:2](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/errors.ts#L2)
 
 ## Properties
 
@@ -60,7 +60,7 @@ Error.message
 
 node_modules/typescript/lib/lib.es5.d.ts:1054
 
-___
+---
 
 ### name
 
@@ -74,7 +74,7 @@ Error.name
 
 node_modules/typescript/lib/lib.es5.d.ts:1053
 
-___
+---
 
 ### stack
 
@@ -88,7 +88,7 @@ Error.stack
 
 node_modules/typescript/lib/lib.es5.d.ts:1055
 
-___
+---
 
 ### prepareStackTrace
 
@@ -100,15 +100,13 @@ ___
 
 Optional override for formatting stack traces
 
-**`See`**
-
-https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `err` | `Error` |
+| Name          | Type         |
+| :------------ | :----------- |
+| `err`         | `Error`      |
 | `stackTraces` | `CallSite`[] |
 
 ##### Returns
@@ -121,9 +119,9 @@ Error.prepareStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:11
+node_modules/@types/node/globals.d.ts:27
 
-___
+---
 
 ### stackTraceLimit
 
@@ -135,7 +133,7 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:13
+node_modules/@types/node/globals.d.ts:29
 
 ## Methods
 
@@ -147,9 +145,9 @@ Create .stack property on a target object
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `targetObject` | `object` |
+| Name              | Type       |
+| :---------------- | :--------- |
+| `targetObject`    | `object`   |
 | `constructorOpt?` | `Function` |
 
 #### Returns
@@ -162,4 +160,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:4
+node_modules/@types/node/globals.d.ts:20

--- a/docs/classes/JsonApiFractalError.md
+++ b/docs/classes/JsonApiFractalError.md
@@ -44,7 +44,7 @@ Error.constructor
 
 #### Defined in
 
-[src/errors.ts:2](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/errors.ts#L2)
+[src/errors.ts:2](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/errors.ts#L2)
 
 ## Properties
 

--- a/docs/classes/Transformer.md
+++ b/docs/classes/Transformer.md
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[src/transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L8)
+[src/transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L8)
 
 ## Properties
 
@@ -55,7 +55,7 @@
 
 #### Defined in
 
-[src/transformer.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L5)
+[src/transformer.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L5)
 
 ---
 
@@ -65,7 +65,7 @@
 
 #### Defined in
 
-[src/transformer.ts:4](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L4)
+[src/transformer.ts:4](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L4)
 
 ## Methods
 
@@ -86,4 +86,4 @@
 
 #### Defined in
 
-[src/transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L6)
+[src/transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L6)

--- a/docs/classes/Transformer.md
+++ b/docs/classes/Transformer.md
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[src/transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L8)
+[src/transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L8)
 
 ## Properties
 
@@ -55,7 +55,7 @@
 
 #### Defined in
 
-[src/transformer.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L5)
+[src/transformer.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L5)
 
 ---
 
@@ -65,7 +65,7 @@
 
 #### Defined in
 
-[src/transformer.ts:4](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L4)
+[src/transformer.ts:4](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L4)
 
 ## Methods
 
@@ -86,4 +86,4 @@
 
 #### Defined in
 
-[src/transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/transformer.ts#L6)
+[src/transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/transformer.ts#L6)

--- a/docs/classes/Transformer.md
+++ b/docs/classes/Transformer.md
@@ -4,9 +4,9 @@
 
 ## Type parameters
 
-| Name |
-| :------ |
-| `TEntity` |
+| Name            |
+| :-------------- |
+| `TEntity`       |
 | `TExtraOptions` |
 
 ## Hierarchy
@@ -38,14 +38,14 @@
 
 #### Type parameters
 
-| Name |
-| :------ |
-| `TEntity` |
+| Name            |
+| :-------------- |
+| `TEntity`       |
 | `TExtraOptions` |
 
 #### Defined in
 
-[src/transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L8)
+[src/transformer.ts:8](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L8)
 
 ## Properties
 
@@ -55,9 +55,9 @@
 
 #### Defined in
 
-[src/transformer.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L5)
+[src/transformer.ts:5](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L5)
 
-___
+---
 
 ### type
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[src/transformer.ts:4](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L4)
+[src/transformer.ts:4](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L4)
 
 ## Methods
 
@@ -75,9 +75,9 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `entity` | `TEntity` |
+| Name      | Type                                                |
+| :-------- | :-------------------------------------------------- |
+| `entity`  | `TEntity`                                           |
 | `options` | [`Options`](../README.md#options)<`TExtraOptions`\> |
 
 #### Returns
@@ -86,4 +86,4 @@ ___
 
 #### Defined in
 
-[src/transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/transformer.ts#L6)
+[src/transformer.ts:6](https://github.com/andersondanilo/jsonapi-fractal/blob/43f9c51/src/transformer.ts#L6)

--- a/docs/enums/CaseType.md
+++ b/docs/enums/CaseType.md
@@ -4,38 +4,38 @@
 
 ## Table of contents
 
-### Enumeration Members
+### Enumeration members
 
 - [camelCase](CaseType.md#camelcase)
 - [kebabCase](CaseType.md#kebabcase)
 - [snakeCase](CaseType.md#snakecase)
 
-## Enumeration Members
+## Enumeration members
 
 ### camelCase
 
-• **camelCase** = ``"camelCase"``
+• **camelCase** = `"camelCase"`
 
 #### Defined in
 
-[src/types.ts:45](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L45)
+[src/types.ts:45](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L45)
 
-___
+---
 
 ### kebabCase
 
-• **kebabCase** = ``"kebabCase"``
+• **kebabCase** = `"kebabCase"`
 
 #### Defined in
 
-[src/types.ts:47](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L47)
+[src/types.ts:47](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L47)
 
-___
+---
 
 ### snakeCase
 
-• **snakeCase** = ``"snakeCase"``
+• **snakeCase** = `"snakeCase"`
 
 #### Defined in
 
-[src/types.ts:46](https://github.com/andersondanilo/jsonapi-fractal/blob/9e4f6c2/src/types.ts#L46)
+[src/types.ts:46](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L46)

--- a/docs/enums/CaseType.md
+++ b/docs/enums/CaseType.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/types.ts:45](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L45)
+[src/types.ts:45](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L45)
 
 ---
 
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[src/types.ts:47](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L47)
+[src/types.ts:47](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L47)
 
 ---
 
@@ -38,4 +38,4 @@
 
 #### Defined in
 
-[src/types.ts:46](https://github.com/andersondanilo/jsonapi-fractal/blob/dec09c6/src/types.ts#L46)
+[src/types.ts:46](https://github.com/andersondanilo/jsonapi-fractal/blob/5f3ab68/src/types.ts#L46)

--- a/src/default-transformer.ts
+++ b/src/default-transformer.ts
@@ -1,9 +1,10 @@
 import { RelationshipTransformerInfo, RelationshipTransformerInfoFunction, Transformer } from './transformer'
-import { AttributesObject } from './types'
+import { AttributesObject, Options } from './types'
 import { createRecordFromKeys } from './utils'
 
 export class DefaultTransformer<TEntity = unknown, TExtraOptions = void> extends Transformer<TEntity, TExtraOptions> {
   public readonly relationships: Record<string, RelationshipTransformerInfoFunction<TEntity, TExtraOptions>>
+  public readonly options?: Options<TExtraOptions>
 
   constructor(public type: string, relationships: string[] | Record<string, string> = []) {
     super()
@@ -27,6 +28,10 @@ export class DefaultTransformer<TEntity = unknown, TExtraOptions = void> extends
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transform(entity: any): AttributesObject {
     const attributes = { ...entity }
+
+    if (this.options && this.options.typeKey) {
+      delete attributes[this.options.typeKey]
+    }
 
     for (const relationship in this.relationships) {
       delete attributes[relationship]

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -1,4 +1,4 @@
-import { AttributesObject, DocumentObject, ExistingResourceObject, Options, ResourceObject } from './types'
+import { AttributesObject, DocumentObject, ExistingResourceObject, DeserializeOptions, ResourceObject } from './types'
 import { caseTypes, changeCase } from './utils'
 
 type IncludedCache = Record<string, Record<string, unknown>>
@@ -11,7 +11,7 @@ type IncludedCache = Record<string, Record<string, unknown>>
  */
 export function deserialize<TEntity, TExtraOptions = unknown>(
   response: DocumentObject,
-  options: Options<TExtraOptions> = {},
+  options: DeserializeOptions<TExtraOptions> = {},
 ): TEntity | TEntity[] | undefined {
   if (!response.data) {
     return undefined
@@ -31,7 +31,7 @@ export const typeField = Symbol('type')
 function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   data: ResourceObject,
   included: ExistingResourceObject[],
-  options: Options<TExtraOptions>,
+  options: DeserializeOptions<TExtraOptions>,
   useCache: boolean,
   includedCache: IncludedCache,
 ): TEntity {
@@ -52,7 +52,7 @@ function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   }
 
   const resource: Record<string, unknown> = {
-    [typeField]: data.type,
+    ...(options.injectType ? { [typeField]: data.type } : {}),
     ...(id ? { id } : {}),
     ...attributes,
   }
@@ -116,12 +116,12 @@ function findJsonApiIncluded<TEntity, TExtraOptions>(
   includedCache: IncludedCache,
   type: string,
   id: string,
-  options: Options<TExtraOptions>,
+  options: DeserializeOptions<TExtraOptions>,
 ): TEntity {
   const foundResource = included.find((item) => item.type === type && item.id === id)
 
   if (!foundResource) {
-    return { id, [typeField]: type } as unknown as TEntity
+    return { id, ...(options.injectType ? { [typeField]: type } : {}), } as unknown as TEntity
   }
 
   return parseJsonApiSimpleResourceData(foundResource, included, options, true, includedCache)

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -1,4 +1,4 @@
-import { AttributesObject, DocumentObject, ExistingResourceObject, DeserializeOptions, ResourceObject } from './types'
+import { AttributesObject, DocumentObject, ExistingResourceObject, Options, ResourceObject } from './types'
 import { caseTypes, changeCase } from './utils'
 
 type IncludedCache = Record<string, Record<string, unknown>>
@@ -11,7 +11,7 @@ type IncludedCache = Record<string, Record<string, unknown>>
  */
 export function deserialize<TEntity, TExtraOptions = unknown>(
   response: DocumentObject,
-  options: DeserializeOptions<TExtraOptions> = {},
+  options: Options<TExtraOptions> = {},
 ): TEntity | TEntity[] | undefined {
   if (!response.data) {
     return undefined
@@ -29,7 +29,7 @@ export function deserialize<TEntity, TExtraOptions = unknown>(
 function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   data: ResourceObject,
   included: ExistingResourceObject[],
-  options: DeserializeOptions<TExtraOptions>,
+  options: Options<TExtraOptions>,
   useCache: boolean,
   includedCache: IncludedCache,
 ): TEntity {
@@ -114,7 +114,7 @@ function findJsonApiIncluded<TEntity, TExtraOptions>(
   includedCache: IncludedCache,
   type: string,
   id: string,
-  options: DeserializeOptions<TExtraOptions>,
+  options: Options<TExtraOptions>,
 ): TEntity {
   const foundResource = included.find((item) => item.type === type && item.id === id)
 

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -26,8 +26,6 @@ export function deserialize<TEntity, TExtraOptions = unknown>(
     : parseJsonApiSimpleResourceData(response.data, included, options, false, {})
 }
 
-export const typeField = Symbol('type')
-
 function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   data: ResourceObject,
   included: ExistingResourceObject[],
@@ -52,7 +50,7 @@ function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   }
 
   const resource: Record<string, unknown> = {
-    ...(options.injectType ? { [typeField]: data.type } : {}),
+    ...(options.typeKey ? { [options.typeKey]: data.type } : {}),
     ...(id ? { id } : {}),
     ...attributes,
   }
@@ -121,7 +119,7 @@ function findJsonApiIncluded<TEntity, TExtraOptions>(
   const foundResource = included.find((item) => item.type === type && item.id === id)
 
   if (!foundResource) {
-    return { id, ...(options.injectType ? { [typeField]: type } : {}), } as unknown as TEntity
+    return { id, ...(options.typeKey ? { [options.typeKey]: type } : {}), } as unknown as TEntity
   }
 
   return parseJsonApiSimpleResourceData(foundResource, included, options, true, includedCache)

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -26,6 +26,8 @@ export function deserialize<TEntity, TExtraOptions = unknown>(
     : parseJsonApiSimpleResourceData(response.data, included, options, false, {})
 }
 
+export const typeField = Symbol('type')
+
 function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   data: ResourceObject,
   included: ExistingResourceObject[],
@@ -50,6 +52,7 @@ function parseJsonApiSimpleResourceData<TEntity, TExtraOptions>(
   }
 
   const resource: Record<string, unknown> = {
+    [typeField]: data.type,
     ...(id ? { id } : {}),
     ...attributes,
   }
@@ -118,7 +121,7 @@ function findJsonApiIncluded<TEntity, TExtraOptions>(
   const foundResource = included.find((item) => item.type === type && item.id === id)
 
   if (!foundResource) {
-    return { id } as unknown as TEntity
+    return { id, [typeField]: type } as unknown as TEntity
   }
 
   return parseJsonApiSimpleResourceData(foundResource, included, options, true, includedCache)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
 export * from './types'
 export { DefaultTransformer } from './default-transformer'
 export { Context, ContextBuilder } from './context'
-export { deserialize, typeField } from './deserializer'
+export { deserialize } from './deserializer'
 export { serialize, transform } from './serializer'
 export { whitelist } from './utils'
 export { JsonApiFractalError } from './errors'

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
 export * from './types'
 export { DefaultTransformer } from './default-transformer'
 export { Context, ContextBuilder } from './context'
-export { deserialize } from './deserializer'
+export { deserialize, typeField } from './deserializer'
 export { serialize, transform } from './serializer'
 export { whitelist } from './utils'
 export { JsonApiFractalError } from './errors'

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -42,7 +42,8 @@ export function serialize<TEntity, TExtraOptions = unknown>(
     if (options.idKey === options.typeKey) {
       throw new JsonApiFractalError('idKey and typeKey must be different')
     }
-    if ((data as any)[options.typeKey] !== type) {
+    const typeFromTypeKey = (data as any)[options.typeKey]
+    if (typeFromTypeKey && typeFromTypeKey !== type) {
       throw new JsonApiFractalError('typeKey and type must be the same')
     }
   }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -38,6 +38,15 @@ export function serialize<TEntity, TExtraOptions = unknown>(
     options = {} as SerializeOptions<TExtraOptions>
   }
 
+  if (options.typeKey) {
+    if (options.idKey === options.typeKey) {
+      throw new JsonApiFractalError('idKey and typeKey must be different')
+    }
+    if ((data as any)[options.typeKey] !== type) {
+      throw new JsonApiFractalError('typeKey and type must be the same')
+    }
+  }
+
   return transform()
     .withInput(data)
     .withTransformer(new DefaultTransformer(type, options.relationships || []))
@@ -83,10 +92,14 @@ function serializeEntity<TEntity, TExtraOptions>(
 ): ResourceObject | NewResourceObject {
   let attributes = { ...transformer.transform(entity, options) }
   const idKey = options.idKey || 'id'
+  const baseKey = options.typeKey;
   const id: string | undefined =
     (attributes[idKey] as string) || (entity as unknown as Record<string, string>)[idKey] || undefined
 
   delete attributes[idKey]
+  if (baseKey) {
+    delete attributes[baseKey]
+  }
 
   const relationships: Record<string, RelationshipObject> = {}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,8 @@ export enum CaseType {
 export type Options<TExtraOptions = void> = {
   /** key that should be used as the id */
   idKey?: string
+  /** key that should be used as the type */
+  typeKey?: string
   /** map of EntityType => Fields Array, e.g. `{"users": ["name", "age"], "images": ["width"]}` */
   fields?: Record<string, string[]>
   /** change case of the attribute keys */
@@ -60,11 +62,6 @@ export type Options<TExtraOptions = void> = {
   extra?: TExtraOptions
 }
 
-
-export type DeserializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
-  /** key that should be used as the type */
-  typeKey?: string
-}
 
 export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
   relationships?: string[] | Record<string, string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,12 @@ export type Options<TExtraOptions = void> = {
   extra?: TExtraOptions
 }
 
+
+export type DeserializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
+  /** inject `type` as a symbol */
+  injectType?: boolean
+}
+
 export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
   relationships?: string[] | Record<string, string>
   included?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,8 +62,8 @@ export type Options<TExtraOptions = void> = {
 
 
 export type DeserializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {
-  /** inject `type` as a symbol */
-  injectType?: boolean
+  /** key that should be used as the type */
+  typeKey?: string
 }
 
 export type SerializeOptions<TExtraOptions = void> = Options<TExtraOptions> & {

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -1,4 +1,4 @@
-import { deserialize, DocumentObject } from '../src'
+import { deserialize, typeField, DocumentObject } from '../src'
 import { CaseType } from '../src/types'
 
 describe('deserialize', () => {
@@ -42,13 +42,18 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         address: {
           id: '1',
+          [typeField]: 'addr',
           street: 'Street 1',
         },
-        images: [{ id: '1' }, { id: '2' }],
+        images: [
+          { id: '1', [typeField]: 'img' },
+          { id: '2', [typeField]: 'img' },
+        ],
       },
     ])
   })
@@ -101,6 +106,7 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         links: {
@@ -109,13 +115,17 @@ describe('deserialize', () => {
         },
         address: {
           id: '1',
+          [typeField]: 'addr',
           street: 'Street 1',
           links: {
             self: 'https://example.org/address/1/relationships/address',
             related: 'https://example.org/address/1',
           },
         },
-        images: [{ id: '1' }, { id: '2' }],
+        images: [
+          { id: '1', [typeField]: 'img' },
+          { id: '2', [typeField]: 'img' },
+        ],
       },
     ])
   })
@@ -154,10 +164,12 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         homeAddress: {
           id: '1',
+          [typeField]: 'addr',
           street: 'Street 1',
         },
       },

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -42,6 +42,18 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        firstName: 'Joe',
+        lastName: 'Doe',
+        address: {
+          id: '1',
+          street: 'Street 1',
+        },
+        images: [{ id: '1' }, { id: '2' }],
+      },
+    ])
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, injectType: true })).toStrictEqual([
+      {
+        id: '1',
         [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
@@ -106,6 +118,26 @@ describe('deserialize', () => {
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
       {
         id: '1',
+        firstName: 'Joe',
+        lastName: 'Doe',
+        links: {
+          self: 'https://example.org/users/1',
+          action: 'https://example.org/action',
+        },
+        address: {
+          id: '1',
+          street: 'Street 1',
+          links: {
+            self: 'https://example.org/address/1/relationships/address',
+            related: 'https://example.org/address/1',
+          },
+        },
+        images: [{ id: '1' }, { id: '2' }],
+      },
+    ])
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, injectType: true })).toStrictEqual([
+      {
+        id: '1',
         [typeField]: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
@@ -162,6 +194,17 @@ describe('deserialize', () => {
     }
 
     expect(deserialize(serialized, { changeCase: CaseType.camelCase })).toStrictEqual([
+      {
+        id: '1',
+        firstName: 'Joe',
+        lastName: 'Doe',
+        homeAddress: {
+          id: '1',
+          street: 'Street 1',
+        },
+      },
+    ])
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, injectType: true })).toStrictEqual([
       {
         id: '1',
         [typeField]: 'users',

--- a/tests/deserialize.spec.ts
+++ b/tests/deserialize.spec.ts
@@ -1,4 +1,4 @@
-import { deserialize, typeField, DocumentObject } from '../src'
+import { deserialize, DocumentObject } from '../src'
 import { CaseType } from '../src/types'
 
 describe('deserialize', () => {
@@ -51,20 +51,37 @@ describe('deserialize', () => {
         images: [{ id: '1' }, { id: '2' }],
       },
     ])
-    expect(deserialize(serialized, { changeCase: CaseType.camelCase, injectType: true })).toStrictEqual([
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, typeKey: 'type' })).toStrictEqual([
       {
         id: '1',
-        [typeField]: 'users',
+        type: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         address: {
           id: '1',
-          [typeField]: 'addr',
+          type: 'addr',
           street: 'Street 1',
         },
         images: [
-          { id: '1', [typeField]: 'img' },
-          { id: '2', [typeField]: 'img' },
+          { id: '1', type: 'img' },
+          { id: '2', type: 'img' },
+        ],
+      },
+    ])
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, typeKey: 'foo' })).toStrictEqual([
+      {
+        id: '1',
+        foo: 'users',
+        firstName: 'Joe',
+        lastName: 'Doe',
+        address: {
+          id: '1',
+          foo: 'addr',
+          street: 'Street 1',
+        },
+        images: [
+          { id: '1', foo: 'img' },
+          { id: '2', foo: 'img' },
         ],
       },
     ])
@@ -135,10 +152,10 @@ describe('deserialize', () => {
         images: [{ id: '1' }, { id: '2' }],
       },
     ])
-    expect(deserialize(serialized, { changeCase: CaseType.camelCase, injectType: true })).toStrictEqual([
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, typeKey: 'type' })).toStrictEqual([
       {
         id: '1',
-        [typeField]: 'users',
+        type: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         links: {
@@ -147,7 +164,7 @@ describe('deserialize', () => {
         },
         address: {
           id: '1',
-          [typeField]: 'addr',
+          type: 'addr',
           street: 'Street 1',
           links: {
             self: 'https://example.org/address/1/relationships/address',
@@ -155,8 +172,8 @@ describe('deserialize', () => {
           },
         },
         images: [
-          { id: '1', [typeField]: 'img' },
-          { id: '2', [typeField]: 'img' },
+          { id: '1', type: 'img' },
+          { id: '2', type: 'img' },
         ],
       },
     ])
@@ -204,15 +221,15 @@ describe('deserialize', () => {
         },
       },
     ])
-    expect(deserialize(serialized, { changeCase: CaseType.camelCase, injectType: true })).toStrictEqual([
+    expect(deserialize(serialized, { changeCase: CaseType.camelCase, typeKey: 'type' })).toStrictEqual([
       {
         id: '1',
-        [typeField]: 'users',
+        type: 'users',
         firstName: 'Joe',
         lastName: 'Doe',
         homeAddress: {
           id: '1',
-          [typeField]: 'addr',
+          type: 'addr',
           street: 'Street 1',
         },
       },

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -110,6 +110,34 @@ describe('serialize', () => {
     expect(getSerialized).toThrowError(new JsonApiFractalError('typeKey and type must be the same'))
   })
 
+  it('shouldn’t throw if the typeKey doesn’t match the type written, but typeKey isn’t present', () => {
+    const serialized = serialize(validEntity, 'users', { ...validOptions, typeKey: 'type' })
+
+    expect(serialized).toStrictEqual({
+      data: {
+        type: 'users',
+        attributes: {
+          'first-name': 'Joe',
+          'last-name': 'Doe',
+        },
+        relationships: {
+          address: {
+            data: {
+              type: 'address',
+              id: 'address-1',
+            },
+          },
+          images: {
+            data: [
+              { type: 'images', id: 'image-1' },
+              { type: 'images', id: 'image-2' },
+            ],
+          },
+        },
+      },
+    })
+  })
+
   it('should throw if the typeKey and idKey are the same', () => {
     const getSerialized = () => serialize({ ...validEntity, type: 'users' }, 'users', { ...validOptions, typeKey: 'type', idKey: 'type' })
 

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -1,4 +1,4 @@
-import { serialize } from '../src'
+import { JsonApiFractalError, serialize } from '../src'
 import { CaseType, SerializeOptions } from '../src/types'
 
 describe('serialize', () => {
@@ -74,6 +74,46 @@ describe('serialize', () => {
       // eslint-disable-next-line unicorn/no-null
       data: null,
     })
+  })
+
+  it('should accept and match a typeKey', () => {
+    const serialized = serialize({ ...validEntity, type: 'users' }, 'users', { ...validOptions, typeKey: 'type' })
+
+    expect(serialized).toStrictEqual({
+      data: {
+        type: 'users',
+        attributes: {
+          'first-name': 'Joe',
+          'last-name': 'Doe',
+        },
+        relationships: {
+          address: {
+            data: {
+              type: 'address',
+              id: 'address-1',
+            },
+          },
+          images: {
+            data: [
+              { type: 'images', id: 'image-1' },
+              { type: 'images', id: 'image-2' },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  it('should throw if the typeKey doesn’t match the type written', () => {
+    const getSerialized = () => serialize({ ...validEntity, type: 'user' }, 'users', { ...validOptions, typeKey: 'type' })
+
+    expect(getSerialized).toThrowError(new JsonApiFractalError('typeKey and type must be the same'))
+  })
+
+  it('should throw if the typeKey and idKey are the same', () => {
+    const getSerialized = () => serialize({ ...validEntity, type: 'users' }, 'users', { ...validOptions, typeKey: 'type', idKey: 'type' })
+
+    expect(getSerialized).toThrowError(new JsonApiFractalError('idKey and typeKey must be different'))
   })
 
   it('should accept entity array', () => {


### PR DESCRIPTION
Fix https://github.com/andersondanilo/jsonapi-fractal/issues/138. Variation of https://github.com/andersondanilo/jsonapi-fractal/pull/139 using `typeKey` instead of `typeField`

- Add new option `typeKey?: string` for deserialization to include all JSON:API types during deserialization
- During serialization, will check if `typeKey` matches the provided `type` (but keep `typeKey` optional)
- Regenerate docs

